### PR TITLE
fix: wrap cleanup funcs in closure to capture correct attrs

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,17 +51,19 @@ function context () {
         for (var k in l) {
           if('function' === typeof l[k]) {
             if(/^on\w+/.test(k)) {
-              if (e.addEventListener){
-                e.addEventListener(k.substring(2), l[k], false)
-                cleanupFuncs.push(function(){
-                  e.removeEventListener(k.substring(2), l[k], false)
-                })
-              }else{
-                e.attachEvent(k, l[k])
-                cleanupFuncs.push(function(){
-                  e.detachEvent(k, l[k])
-                })
-              }
+              (function (k, l) { // capture k, l in the closure
+                if (e.addEventListener){
+                  e.addEventListener(k.substring(2), l[k], false)
+                  cleanupFuncs.push(function(){
+                    e.removeEventListener(k.substring(2), l[k], false)
+                  })
+                }else{
+                  e.attachEvent(k, l[k])
+                  cleanupFuncs.push(function(){
+                    e.detachEvent(k, l[k])
+                  })
+                }
+              })(k, l)
             } else {
               // observable
               e[k] = l[k]()


### PR DESCRIPTION
this fixes an exception that's thrown in firefox