### PR TITLE
Added support for arbitrary attributes and !important styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,10 +84,20 @@ function context () {
                     e.style.setProperty(s, val)
                   }))
                 } else
-                  e.style.setProperty(s, l[k][s])
+                  var match = l[k][s].match(/(.*)\W+!important\W*$/);
+                  if (match) {
+                    e.style.setProperty(s, match[1], 'important')
+                  } else {
+                    e.style.setProperty(s, l[k][s])
+                  }
               })(s, l[k][s])
             }
-          } else if (k.substr(0, 5) === "data-") {
+          } else if(k === 'attrs') {
+            for (var v in l[k]) {
+              e.setAttribute(v, l[k][v]);
+            }
+          }
+          else if (k.substr(0, 5) === "data-") {
             e.setAttribute(k, l[k])
           } else {
             e[k] = l[k]

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function context () {
             }
           } else if(k === 'attrs') {
             for (var v in l[k]) {
-              e.setAttribute(v, l[k][v]);
+              e.setAttribute(v, l[k][v])
             }
           }
           else if (k.substr(0, 5) === "data-") {


### PR DESCRIPTION
Mostly a fix for #6. I couldn't find any way to set arbitrary attributes in a browser environments. This adds a special `attrs` property with special handling analogous to that of `style`.

I also added support for `!important` flags on styles. Currently if you say something like `style: { 'width: 800px !important' }`, `setProperty` will ignore the style entirely.