### PR TITLE
Accept unicode characters in selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function context () {
     function item (l) {
       var r
       function parseClass (string) {
-        var m = split(string, /([\.#]?[a-zA-Z0-9_:-]+)/)
+        var m = split(string, /([\.#]?[^\s#.]+)/)
         if(/^\.|#/.test(m[1]))
           e = document.createElement('div')
         forEach(m, function (v) {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ function context () {
     function item (l) {
       var r
       function parseClass (string) {
+        // Our minimal parser doesn’t understand escaping CSS special
+        // characters like `#`. Don’t use them. More reading:
+        // https://mathiasbynens.be/notes/css-escapes .
+
         var m = split(string, /([\.#]?[^\s#.]+)/)
         if(/^\.|#/.test(m[1]))
           e = document.createElement('div')

--- a/test/index.js
+++ b/test/index.js
@@ -152,3 +152,9 @@ test('context cleanup removes event handlers', function(t){
   t.assert(!onClick.called, 'click listener was not triggered')
   t.end()
 })
+
+test('unicode selectors', function (t) {
+  t.equal(h('.⛄').outerHTML, '<div class="⛄"></div>')
+  t.equal(h('span#⛄').outerHTML, '<span id="⛄"></span>')
+  t.end()
+})


### PR DESCRIPTION
(https://github.com/dominictarr/hyperscript/issues/38)

Any unicode character which doesn’t have a special meaning in CSS can be used in a class/id selector without escaping: http://jsbin.com/talosehanu/3/edit?html,css,js,console,output.

More info here: https://mathiasbynens.be/notes/css-escapes.

In this PR I’ve ignored the rules for escaping and un-escaping characters. For example, `div.a\#b#c\.d` should theoretically be read as `<div class="a#b" id="c.d" />`. That’s implementable, but it costs a lot of code and I don’t think it’s worth it. Would anyone really use things `#` in a selector? But @dominictarr let me know if you’d rather have your mini parser as close to the spec as possible.

11 tests are failing on my box. I’ve added two more and made sure I don’t break any other.