### PR TITLE
Added trusted/raw HTML feature

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -20,12 +20,12 @@ document.body.appendChild(
         h('li', 'three'))),
     h('div#content', {style: {float: 'left'} },
       h('h2', 'content title'),
-      h('p', 
+      h('p',
         "so it's just like a templating engine,\n",
         "but easy to use inline with javascript\n"),
-      h('p', 
+      h('p',
         "the intension is for this to be used to create\n",
-        "reusable, interactive html widgets. ")))
+        h.trust("<em>reusable</em>, <strong>interactive</strong> html widgets. "))))
 )
 
 </script>

--- a/index.js
+++ b/index.js
@@ -38,6 +38,20 @@ function context () {
         else
           e.appendChild(r = document.createTextNode(l))
       }
+      else if(l instanceof String) {
+        // this may be 'trusted' HTML
+        if(e && l.$trusted) {
+          // assume trusted HTML
+          e.innerHTML = l.toString()
+        }
+        else {
+          // handle as we would a plain string
+          if(!e)
+            parseClass(l.toString())
+          else
+            e.appendChild(r = document.createTextNode(l.toString()))
+        }
+      }
       else if('number' === typeof l
         || 'boolean' === typeof l
         || l instanceof Date
@@ -123,6 +137,14 @@ function context () {
       cleanupFuncs[i]()
     }
     cleanupFuncs.length = 0
+  }
+
+  // Make a string that is recognized as trusted html
+  // (Uses mithril's conventions)
+  h.trust = function (html) {
+    var s = new String(html)
+    s.$trusted = true
+    return s
   }
 
   return h

--- a/test/index.js
+++ b/test/index.js
@@ -158,3 +158,11 @@ test('unicode selectors', function (t) {
   t.equal(h('span#⛄').outerHTML, '<span id="⛄"></span>')
   t.end()
 })
+
+test('trust', function (t) {
+  t.equal(
+    h('p', h.trust('<em>hello</em> <strong>world</strong>')).outerHTML,
+    '<p><em>hello</em> <strong>world</strong></p>'
+  )
+  t.end()
+})


### PR DESCRIPTION
This allows you to include raw HTML in your hyperscript. Example:

    h('p', h.trust('<em>hello</em> <strong>world</strong>'))

This is useful if you need to include HTML content from a trusted feed or CMS with rich text fields.

I've followed [mithril.js's conventions](https://github.com/lhorie/mithril.js/blob/next/mithril.js#L1249-L1253) for the implementation.