### PR TITLE
upgrade html-element to v2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var split = require('browser-split')
 var ClassList = require('class-list')
-require('html-element')
+require('html-element/global-shim')
 
 function context () {
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 var split = require('browser-split')
 var ClassList = require('class-list')
-require('html-element/global-shim')
+var htmlElement = require('html-element');
+
+var document = htmlElement.document;
+var Text = htmlElement.Text;
 
 function context () {
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "browser-split": "0.0.0",
     "class-list": "~0.1.0",
-    "html-element": "^1.4.0"
+    "html-element": "^2.0.0"
   },
   "browser": {
     "html-element": false

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
+global.document = require('html-element').document;
 
 var test = require('tape')
 var h    = require('../')


### PR DESCRIPTION
As noted in https://github.com/1N50MN14/html-element#upgrading-from-v1x,
you now need a slightly different 'require' in order to get globals
injected automatically.

This should take care of all backwards-incompatible changes if you want to
use new versions of `html-element`.

FYI I get some tests failing locally, but these are also failing for me on master...